### PR TITLE
Improve trap_exit function

### DIFF
--- a/bash_basic_functions.sh
+++ b/bash_basic_functions.sh
@@ -503,11 +503,25 @@ show()
 #########################################################################
 trap_exit()
 {
-    OS_name=$(uname -a | awk '{print $1}')  # get OS name (Darwin or Linux)
+    # Check how the parent script was invoked
+    # S+ means from script
+    # Ss means from command line
+    # Details - https://stackoverflow.com/a/4262107
+    invoked_as=$(ps -o stat= -p $PPID)
 
-    if [[ $OS_name == "Linux" ]]; then
-        sleep 1;kill -SIGUSR1 `ps --pid $$ -o ppid=`#;exit   # Find parent process ID (ppid) and set user defined signal (SIGUSR1)
-    elif [[ $OS_name == "Darwin" ]]; then
-        sleep 1;kill -SIGUSR1 `ps $$ -o ppid=`#;exit         # Find parent process ID (ppid) and set user defined signal (SIGUSR1)
+    # Run from command line -> run simple exit
+    if [[ ${invoked_as} == "Ss" ]];then
+        exit
+    # Run from script -> kill the parent script
+    else
+        return
+
+#        OS_name=$(uname -a | awk '{print $1}')  # get OS name (Darwin or Linux)
+#
+#        if [[ $OS_name == "Linux" ]]; then
+#            sleep 1;kill -SIGUSR1 $(ps --pid $$ -o ppid=) #;exit   # Find parent process ID (ppid) and set user defined signal (SIGUSR1)
+#        elif [[ $OS_name == "Darwin" ]]; then
+#            sleep 1;kill -SIGUSR1 $(ps $$ -o ppid=) #;exit         # Find parent process ID (ppid) and set user defined signal (SIGUSR1)
+#        fi
     fi
 }


### PR DESCRIPTION
Improve `trap_exit` function to recognize if the parent script is run from CLI or another parent script. The function now recognizes if it was run from another script or from CLI. If former, `return` is used to "stop/kill" parent script, if later, exit is used.

This might fix the issue when whole terminal session was killed when some function/script was run from CLI.

Further testing is needed. 

